### PR TITLE
increase refresh timeout

### DIFF
--- a/src/js/AdminPortal/index.js
+++ b/src/js/AdminPortal/index.js
@@ -7,7 +7,7 @@ import { connectContract } from "../getContract.js";
 
 import "./style.scss";
 
-const REFRESH_RATE = 1000 // (in milliseconds) Refresh every second
+const REFRESH_RATE = 5000 // (in milliseconds) Refresh every 5 seconds
 
 class AdminPortal extends React.Component {
 

--- a/src/js/CustomerPortal/index.js
+++ b/src/js/CustomerPortal/index.js
@@ -7,7 +7,7 @@ import { connectContract } from "../getContract.js";
 
 import "./style.scss";
 
-const REFRESH_RATE = 1000 // (in milliseconds) Refresh every second
+const REFRESH_RATE = 5000 // (in milliseconds) Refresh every 5 seconds
 
 class CustomerPortal extends React.Component {
 


### PR DESCRIPTION
For some reason, `web3` or `testrpc` are giving inconsistent data when polling is active. Sometimes data comes back as null or undefined when no changes have been made. I am increasing the refresh timeout to minimize the jarring effect of data changing on the page.